### PR TITLE
[feat] Add global exception handler

### DIFF
--- a/backend/src/main/java/kr/ac/yonsei/yctech/buskers/auth/GoogleOAuthProvider.java
+++ b/backend/src/main/java/kr/ac/yonsei/yctech/buskers/auth/GoogleOAuthProvider.java
@@ -36,12 +36,9 @@ public class GoogleOAuthProvider {
                 GoogleAccessTokenResponse.class
         );
 
-        if (response.getStatusCode() == HttpStatus.OK) {
-            GoogleAccessTokenResponse body = response.getBody();
-            if (body == null) return "";
-            return body.getAccess_token();
-        }
-        return "";
+        GoogleAccessTokenResponse body = response.getBody();
+        if (body == null) return "";
+        return body.getAccess_token();
     }
 
     public String getGoogleEmail(String code, String redirectUri) {
@@ -54,12 +51,9 @@ public class GoogleOAuthProvider {
                 GoogleUserInfoResponse.class
         );
 
-        if (response.getStatusCode() == HttpStatus.OK) {
-            GoogleUserInfoResponse body = response.getBody();
-            if (body == null) return "";
-            return body.getEmail();
-        }
-        return "";
+        GoogleUserInfoResponse body = response.getBody();
+        if (body == null) return "";
+        return body.getEmail();
     }
 
 }

--- a/backend/src/main/java/kr/ac/yonsei/yctech/buskers/auth/service/AuthService.java
+++ b/backend/src/main/java/kr/ac/yonsei/yctech/buskers/auth/service/AuthService.java
@@ -5,6 +5,8 @@ import kr.ac.yonsei.yctech.buskers.auth.JwtTokenProvider;
 import kr.ac.yonsei.yctech.buskers.auth.domain.RefreshToken;
 import kr.ac.yonsei.yctech.buskers.auth.dto.AuthToken;
 import kr.ac.yonsei.yctech.buskers.auth.repository.RefreshTokenRepository;
+import kr.ac.yonsei.yctech.buskers.common.exception.CustomException;
+import kr.ac.yonsei.yctech.buskers.common.exception.ErrorCode;
 import kr.ac.yonsei.yctech.buskers.user.domain.Member;
 import kr.ac.yonsei.yctech.buskers.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +30,18 @@ public class AuthService {
 
     @Transactional
     public AuthToken signInWithGoogle(String code, String redirectUri) {
-        String email = googleOAuthProvider.getGoogleEmail(code, redirectUri);
+        String email;
+
+        try {
+            email = googleOAuthProvider.getGoogleEmail(code, redirectUri);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.INVALID_OAUTH_TOKEN);
+        }
+
+        if (email.isEmpty()) {
+            throw new CustomException(ErrorCode.INVALID_OAUTH_TOKEN);
+        }
+
         Optional<Member> userByEmail = userService.getUserByEmail(email);
         Member user = userByEmail.orElse(userService.createUser(email, "oauth"));
 

--- a/backend/src/main/java/kr/ac/yonsei/yctech/buskers/common/exception/CustomException.java
+++ b/backend/src/main/java/kr/ac/yonsei/yctech/buskers/common/exception/CustomException.java
@@ -1,0 +1,12 @@
+package kr.ac.yonsei.yctech.buskers.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+}

--- a/backend/src/main/java/kr/ac/yonsei/yctech/buskers/common/exception/ErrorCode.java
+++ b/backend/src/main/java/kr/ac/yonsei/yctech/buskers/common/exception/ErrorCode.java
@@ -1,0 +1,22 @@
+package kr.ac.yonsei.yctech.buskers.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    INVALID_OAUTH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 인증 토큰입니다."),
+
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않은 메서드입니다."),
+
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
+
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+
+}

--- a/backend/src/main/java/kr/ac/yonsei/yctech/buskers/common/exception/ErrorResponse.java
+++ b/backend/src/main/java/kr/ac/yonsei/yctech/buskers/common/exception/ErrorResponse.java
@@ -1,0 +1,23 @@
+package kr.ac.yonsei.yctech.buskers.common.exception;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ErrorResponse {
+
+    private final LocalDateTime timestamp = LocalDateTime.now();
+    private final int status;
+    private final String error;
+    private final String code;
+    private final String message;
+
+    public ErrorResponse(ErrorCode errorCode) {
+        this.status = errorCode.getStatus().value();
+        this.error = errorCode.getStatus().name();
+        this.code = errorCode.name();
+        this.message = errorCode.getMessage();
+    }
+
+}

--- a/backend/src/main/java/kr/ac/yonsei/yctech/buskers/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/kr/ac/yonsei/yctech/buskers/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,37 @@
+package kr.ac.yonsei.yctech.buskers.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    protected ResponseEntity<ErrorResponse> handleCustomException(final CustomException e) {
+        log.error("handleCustomException: {}", e.getErrorCode());
+        return ResponseEntity
+                .status(e.getErrorCode().getStatus().value())
+                .body(new ErrorResponse(e.getErrorCode()));
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(final HttpRequestMethodNotSupportedException e) {
+        log.error("handleHttpRequestMethodNotSupportedException: {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.METHOD_NOT_ALLOWED.getStatus().value())
+                .body(new ErrorResponse(ErrorCode.METHOD_NOT_ALLOWED));
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(final Exception e) {
+        log.error("handleException: {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus().value())
+                .body(new ErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR));
+    }
+
+}


### PR DESCRIPTION
## Motivation

- 서버 내 다양한 예외처리에 대한 일관적 구조
- Exceptions를 한 곳에 모아 관리

## Details

- `ErrorResponse`: 클라이언트에 반환되는 에러 구조
  - `timestamp`: 에러 발생 시각
  - `status`: 에러 HTTP status code
  - `error`: `status`에 해당하는 에러 유형
  - `code`: 커스텀 에러 코드
  - `message`: 커스텀 에러 메시지
- `GlobalExceptionHandler`: 서버에서 발생하는 에러를 catch하여 로그에 기록하고, 클라이언트에 구조화된 에러를 반환